### PR TITLE
Fix MagicPath for generic commands 

### DIFF
--- a/src/Confix.Tool/src/Confix.Tool/Pipelines/ReloadCommandPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Pipelines/ReloadCommandPipeline.cs
@@ -35,26 +35,28 @@ public sealed class ReloadCommandPipeline : Pipeline
                 throw new ExitException();
 
             case ConfigurationScope.Project:
-            {
-                var projectDirectory = configuration.Project!.Directory!;
-                var pipeline = new ProjectReloadPipeline();
-                var projectContext = context
-                    .WithExecutingDirectory(projectDirectory);
+                {
+                    var projectDirectory = configuration.Project!.Directory!;
+                    var pipeline = new ProjectReloadPipeline();
+                    var projectContext = context
+                        .WithExecutingDirectory(projectDirectory)
+                        .WithFeatureCollection();
 
-                await pipeline.ExecuteAsync(services, projectContext);
-                return;
-            }
+                    await pipeline.ExecuteAsync(services, projectContext);
+                    return;
+                }
 
             case ConfigurationScope.Solution:
-            {
-                var solutionDirectory = configuration.Solution!.Directory!;
-                var pipeline = new SolutionReloadPipeline();
-                var solutionContext = context
-                    .WithExecutingDirectory(solutionDirectory);
+                {
+                    var solutionDirectory = configuration.Solution!.Directory!;
+                    var pipeline = new SolutionReloadPipeline();
+                    var solutionContext = context
+                        .WithExecutingDirectory(solutionDirectory)
+                        .WithFeatureCollection();
 
-                await pipeline.ExecuteAsync(services, solutionContext);
-                return;
-            }
+                    await pipeline.ExecuteAsync(services, solutionContext);
+                    return;
+                }
 
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Middlewares/MagicPathRewriterTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Middlewares/MagicPathRewriterTests.cs
@@ -52,4 +52,36 @@ public class MagicPathRewriterTests
         // assert
         Snapshot.Match(result.ToJsonString(new() { WriteIndented = true }));
     }
+
+    [Fact]
+    public void Rewrite_ProjectInNonProjectScope_Ignores(){
+        // arrange
+        var sampleObject = new JsonObject()
+        {
+            ["project"] = "$project:/foo/bar",
+        };
+        var rewriter = new MagicPathRewriter();
+
+        // act
+        var result = rewriter.Rewrite(sampleObject, _context with { ProjectDirectory = null });
+
+        // assert
+        Assert.True(sampleObject.IsEquivalentTo(result));
+    }
+
+    [Fact]
+    public void Rewrite_SolutionInNonSolutionScope_Ignores(){
+        // arrange
+        var sampleObject = new JsonObject()
+        {
+            ["solution"] = "$solution:/foo/bar",
+        };
+        var rewriter = new MagicPathRewriter();
+
+        // act
+        var result = rewriter.Rewrite(sampleObject, _context with { SolutionDirectory = null });
+
+        // assert
+        Assert.True(sampleObject.IsEquivalentTo(result));
+    }
 }


### PR DESCRIPTION
- Fix magicPath rewriter to ignore if not in correct scope instead of exploding
- force config reload in generic reload command


resolves #62 