### PR TITLE
support net7

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   ci-build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '7.0.x', '8.0.x' ]
     defaults:
       run:
         working-directory: ./src/Confix.Tool
@@ -20,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{ matrix.dotnet-version }}
+        global-json-file: ./global.json
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   ci-build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: [ '7.0.x', '8.0.x' ]
     defaults:
       run:
         working-directory: ./src/Confix.Tool
@@ -17,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        global-json-file: ./global.json
+        dotnet-version: ${{ matrix.dotnet-version }}
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          global-json-file: ./global.json
+          dotnet-version: | 
+            7.0.x
+            8.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Import Condition="Exists($(PropsAbove))" Project="$(PropsAbove)"/>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <RootNamespace>ConfiX</RootNamespace>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Import Condition="Exists($(PropsAbove))" Project="$(PropsAbove)"/>
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <RootNamespace>ConfiX</RootNamespace>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <RootNamespace>ConfiX</RootNamespace>
         <Nullable>enable</Nullable>
-        <LangVersion>preview</LangVersion>
+        <LangVersion>11</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 

--- a/examples/Common.Components/src/Common.Components.DataProtection/Common.Components.DataProtection.csproj
+++ b/examples/Common.Components/src/Common.Components.DataProtection/Common.Components.DataProtection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Common.Components/src/Common.Components.DataProtection/Common.Components.DataProtection.csproj
+++ b/examples/Common.Components/src/Common.Components.DataProtection/Common.Components.DataProtection.csproj
@@ -1,11 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildProjectDirectory)/Components/**/*.*"/>
   </ItemGroup>

--- a/examples/Common.Components/src/Common.Components.Security/Common.Components.Security.csproj
+++ b/examples/Common.Components/src/Common.Components.Security/Common.Components.Security.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Common.Components/src/Common.Components.Security/Common.Components.Security.csproj
+++ b/examples/Common.Components/src/Common.Components.Security/Common.Components.Security.csproj
@@ -1,11 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildProjectDirectory)/Components/**/*.*"/>
   </ItemGroup>

--- a/examples/MonoRepo/src/Service1/src/MonoRepo.Service1.Abstraction/MonoRepo.Service1.Abstraction.csproj
+++ b/examples/MonoRepo/src/Service1/src/MonoRepo.Service1.Abstraction/MonoRepo.Service1.Abstraction.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/MonoRepo/src/Service1/src/MonoRepo.Service1.Abstraction/MonoRepo.Service1.Abstraction.csproj
+++ b/examples/MonoRepo/src/Service1/src/MonoRepo.Service1.Abstraction/MonoRepo.Service1.Abstraction.csproj
@@ -1,9 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
 </Project>

--- a/examples/MonoRepo/src/Service1/src/MonoRepo.Service1.Host/MonoRepo.Service1.Host.csproj
+++ b/examples/MonoRepo/src/Service1/src/MonoRepo.Service1.Host/MonoRepo.Service1.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/MonoRepo/src/Service1/src/MonoRepo.Service1.Host/MonoRepo.Service1.Host.csproj
+++ b/examples/MonoRepo/src/Service1/src/MonoRepo.Service1.Host/MonoRepo.Service1.Host.csproj
@@ -1,9 +1,2 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
 </Project>

--- a/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.Abstraction/MonoRepo.Service2.Abstraction.csproj
+++ b/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.Abstraction/MonoRepo.Service2.Abstraction.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.Abstraction/MonoRepo.Service2.Abstraction.csproj
+++ b/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.Abstraction/MonoRepo.Service2.Abstraction.csproj
@@ -1,9 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
 </Project>

--- a/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.DataAccess/MonoRepo.Service2.DataAccess.csproj
+++ b/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.DataAccess/MonoRepo.Service2.DataAccess.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.DataAccess/MonoRepo.Service2.DataAccess.csproj
+++ b/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.DataAccess/MonoRepo.Service2.DataAccess.csproj
@@ -1,9 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
 </Project>

--- a/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.Hosting/MonoRepo.Service2.Hosting.csproj
+++ b/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.Hosting/MonoRepo.Service2.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.Hosting/MonoRepo.Service2.Hosting.csproj
+++ b/examples/MonoRepo/src/Service2/src/MonoRepo.Service2.Hosting/MonoRepo.Service2.Hosting.csproj
@@ -1,9 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
 </Project>

--- a/examples/MonoRepo/src/Shared/src/MonoRepo.Shared.AzureExtensions/MonoRepo.Shared.AzureExtensions.csproj
+++ b/examples/MonoRepo/src/Shared/src/MonoRepo.Shared.AzureExtensions/MonoRepo.Shared.AzureExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/MonoRepo/src/Shared/src/MonoRepo.Shared.AzureExtensions/MonoRepo.Shared.AzureExtensions.csproj
+++ b/examples/MonoRepo/src/Shared/src/MonoRepo.Shared.AzureExtensions/MonoRepo.Shared.AzureExtensions.csproj
@@ -1,9 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
 </Project>

--- a/examples/MonoRepo/src/Shared/src/MonoRepo.Shared.Hosting/MonoRepo.Shared.Hosting.csproj
+++ b/examples/MonoRepo/src/Shared/src/MonoRepo.Shared.Hosting/MonoRepo.Shared.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/MonoRepo/src/Shared/src/MonoRepo.Shared.Hosting/MonoRepo.Shared.Hosting.csproj
+++ b/examples/MonoRepo/src/Shared/src/MonoRepo.Shared.Hosting/MonoRepo.Shared.Hosting.csproj
@@ -1,9 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
 </Project>

--- a/examples/SomeService.Repo/src/SomeService.Abstractions/SomeService.Abstractions.csproj
+++ b/examples/SomeService.Repo/src/SomeService.Abstractions/SomeService.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/SomeService.Repo/src/SomeService.Abstractions/SomeService.Abstractions.csproj
+++ b/examples/SomeService.Repo/src/SomeService.Abstractions/SomeService.Abstractions.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common.Components\src\Common.Components.DataProtection\Common.Components.DataProtection.csproj" />
   </ItemGroup>

--- a/examples/SomeService.Repo/src/SomeService.Host/SomeService.Host.csproj
+++ b/examples/SomeService.Repo/src/SomeService.Host/SomeService.Host.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/examples/SomeService.Repo/src/SomeService.Host/SomeService.Host.csproj
+++ b/examples/SomeService.Repo/src/SomeService.Host/SomeService.Host.csproj
@@ -5,10 +5,4 @@
     <ProjectReference Include="..\..\..\Common.Components\src\Common.Components.Security\Common.Components.Security.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "8.0.100-preview.5.23303.2",
-    "rollForward": "latestMinor"
-  }
-}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100-preview.5.23303.2",
+    "rollForward": "latestMinor"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302"
+    "version": "8.0.100-preview.5.23303.2",
+    "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,5 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.5.23303.2",
-    "rollForward": "latestMinor"
+    "version": "7.0.302"
   }
 }

--- a/poc/k8s-deployment/confixDeploymentTest.csproj
+++ b/poc/k8s-deployment/confixDeploymentTest.csproj
@@ -2,11 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-	<ContainerImageName>timholzherratswisslife/deployment-test</ContainerImageName>
-	<ContainerImageTag>1.0.0</ContainerImageTag>
+    <ContainerImageName>timholzherratswisslife/deployment-test</ContainerImageName>
+    <ContainerImageTag>1.0.0</ContainerImageTag>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Confix.Tool/src/Confix.Tool/Configuration/JsonContext.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Configuration/JsonContext.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Confix.ConfigurationFiles;
 using ConfiX.Variables;
 
@@ -12,4 +14,12 @@ namespace ConfiX.Extensions;
 [JsonSerializable(typeof(AppSettingsConfigurationFileProviderConfiguration))]
 public partial class JsonSerialization : JsonSerializerContext
 {
+    private static readonly JsonSerializerOptions options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    public static JsonSerialization Instance { get; } = new(options);
 }

--- a/src/Confix.Tool/src/Confix.Tool/ConfigurationFile/AppSettings/AppSettingsConfigurationFileProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/ConfigurationFile/AppSettings/AppSettingsConfigurationFileProviderConfiguration.cs
@@ -7,7 +7,6 @@ namespace Confix.ConfigurationFiles;
 
 public class AppSettingsConfigurationFileProviderConfiguration
 {
-    [JsonPropertyName("useUserSecrets")]
     public bool? UseUserSecrets { get; init; }
 
     public static AppSettingsConfigurationFileProviderConfiguration Parse(JsonNode node)

--- a/src/Confix.Tool/src/Confix.Tool/ConfigurationFile/AppSettings/AppSettingsConfigurationFileProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/ConfigurationFile/AppSettings/AppSettingsConfigurationFileProviderConfiguration.cs
@@ -14,7 +14,7 @@ public class AppSettingsConfigurationFileProviderConfiguration
         try
         {
             return node.Deserialize(
-                JsonSerialization.Default.AppSettingsConfigurationFileProviderConfiguration)!;
+                JsonSerialization.Instance.AppSettingsConfigurationFileProviderConfiguration)!;
         }
         catch (JsonException ex)
         {

--- a/src/Confix.Tool/src/Confix.Tool/Confix.Tool.csproj
+++ b/src/Confix.Tool/src/Confix.Tool/Confix.Tool.csproj
@@ -1,15 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-
         <AssemblyName>Confix</AssemblyName>
         <RootNamespace>Confix</RootNamespace>
         <OutputType>Exe</OutputType>
-
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>preview</LangVersion>
-        <Nullable>enable</Nullable>
         <IsPublishable>true</IsPublishable>
     </PropertyGroup>
 

--- a/src/Confix.Tool/src/Confix.Tool/Confix.Tool.csproj
+++ b/src/Confix.Tool/src/Confix.Tool/Confix.Tool.csproj
@@ -6,7 +6,7 @@
         <RootNamespace>Confix</RootNamespace>
         <OutputType>Exe</OutputType>
 
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>

--- a/src/Confix.Tool/src/Confix.Tool/Confix.Tool.csproj
+++ b/src/Confix.Tool/src/Confix.Tool/Confix.Tool.csproj
@@ -23,7 +23,6 @@
         <None Include="../../../../README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
 
-
     <ItemGroup>
         <PackageReference Include="Azure.Identity" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" />

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/AzureKeyVault/AzureKeyVaultProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/AzureKeyVault/AzureKeyVaultProviderConfiguration.cs
@@ -1,15 +1,13 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using ConfiX.Extensions;
 
 namespace ConfiX.Variables;
 
-public sealed record AzureKeyVaultProviderConfiguration
+public sealed record AzureKeyVaultProviderConfiguration(
+    string Uri
+)
 {
-    [JsonPropertyName("Uri")]
-    public required string Uri { get; init; }
-
     public static AzureKeyVaultProviderConfiguration Parse(JsonNode node)
     {
         try

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/AzureKeyVault/AzureKeyVaultProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/AzureKeyVault/AzureKeyVaultProviderConfiguration.cs
@@ -12,7 +12,7 @@ public sealed record AzureKeyVaultProviderConfiguration(
     {
         try
         {
-            return node.Deserialize(JsonSerialization.Default.AzureKeyVaultProviderConfiguration)!;
+            return node.Deserialize(JsonSerialization.Instance.AzureKeyVaultProviderConfiguration)!;
         }
         catch (JsonException ex)
         {

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Git/GitVariableProvider.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Git/GitVariableProvider.cs
@@ -19,10 +19,9 @@ public sealed class GitVariableProvider : IVariableProvider
     {
         _configuration = configuration;
         _cloneDirectory = GetCloneDirectory(configuration);
-        _localVariableProvider = new LocalVariableProvider(new LocalVariableProviderConfiguration
-        {
-            FilePath = Path.Combine(_cloneDirectory, configuration.FilePath)
-        });
+        _localVariableProvider = new LocalVariableProvider(new LocalVariableProviderConfiguration(
+            Path.Combine(_cloneDirectory, configuration.FilePath)
+        ));
     }
 
     public async Task<IReadOnlyList<string>> ListAsync(CancellationToken cancellationToken)

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Git/GitVariableProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Git/GitVariableProviderConfiguration.cs
@@ -1,20 +1,21 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using ConfiX.Extensions;
 
 namespace ConfiX.Variables;
 
 public sealed record GitVariableProviderConfiguration(
-    string RepositoryUrl,
-    string FilePath,
-    string[]? Arguments
+    [property: JsonRequired]string RepositoryUrl,
+    [property: JsonRequired]string FilePath,
+    string[]? Arguments = null
 )
 {
     public static GitVariableProviderConfiguration Parse(JsonNode node)
     {
         try
         {
-            return node.Deserialize(JsonSerialization.Default.GitVariableProviderConfiguration)!;
+            return node.Deserialize(JsonSerialization.Instance.GitVariableProviderConfiguration)!;
         }
         catch (JsonException ex)
         {

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Git/GitVariableProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Git/GitVariableProviderConfiguration.cs
@@ -1,21 +1,15 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using ConfiX.Extensions;
 
 namespace ConfiX.Variables;
 
-public sealed record GitVariableProviderConfiguration
+public sealed record GitVariableProviderConfiguration(
+    string RepositoryUrl,
+    string FilePath,
+    string[]? Arguments
+)
 {
-    [JsonPropertyName("repositoryUrl")]
-    public required string RepositoryUrl { get; init; }
-
-    [JsonPropertyName("filePath")]
-    public required string FilePath { get; init; }
-
-    [JsonPropertyName("arguments")]
-    public string[]? Arguments { get; init; }
-
     public static GitVariableProviderConfiguration Parse(JsonNode node)
     {
         try

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Local/LocalVariableProvider.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Local/LocalVariableProvider.cs
@@ -42,7 +42,7 @@ public sealed class LocalVariableProvider : IVariableProvider
 
     private static Dictionary<string, JsonNode?> ParseConfiguration(LocalVariableProviderConfiguration config)
     {
-        using FileStream fileStream = File.OpenRead(config.FilePath);
+        using FileStream fileStream = File.OpenRead(config.Path);
         JsonNode node = JsonNode.Parse(fileStream) ?? throw new JsonException("Invalid Json Node");
         return JsonParser.ParseNode(node);
     }

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Local/LocalVariableProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Local/LocalVariableProviderConfiguration.cs
@@ -6,14 +6,14 @@ using ConfiX.Extensions;
 namespace ConfiX.Variables;
 
 public sealed record LocalVariableProviderConfiguration(
-  string Path
+  [property: JsonRequired]string Path
 )
 {
     public static LocalVariableProviderConfiguration Parse(JsonNode node)
     {
         try
         {
-            return node.Deserialize(JsonSerialization.Default.LocalVariableProviderConfiguration)!;
+            return node.Deserialize(JsonSerialization.Instance.LocalVariableProviderConfiguration)!;
         }
         catch (JsonException ex)
         {

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Local/LocalVariableProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Local/LocalVariableProviderConfiguration.cs
@@ -5,11 +5,10 @@ using ConfiX.Extensions;
 
 namespace ConfiX.Variables;
 
-public sealed record LocalVariableProviderConfiguration
+public sealed record LocalVariableProviderConfiguration(
+  string Path
+)
 {
-    [JsonPropertyName("path")]
-    public required string FilePath { get; init; }
-
     public static LocalVariableProviderConfiguration Parse(JsonNode node)
     {
         try

--- a/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Secret/SecretVariableProviderConfiguration.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/Providers/Secret/SecretVariableProviderConfiguration.cs
@@ -1,40 +1,26 @@
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using ConfiX.Extensions;
 
 namespace ConfiX.Variables;
 
-public record SecretVariableProviderConfiguration
+public record SecretVariableProviderConfiguration(
+    [property:DefaultValue(SecretVariableProviderAlgorithm.RSA)]
+    SecretVariableProviderAlgorithm Algorithm,
+    [property:DefaultValue(EncryptionPadding.OaepSHA256)]
+    EncryptionPadding Padding,
+    string? PublicKey,
+    string? PublicKeyPath,
+    string? PrivateKey,
+    string? PrivateKeyPath
+)
 {
-    [DefaultValue(SecretVariableProviderAlgorithm.RSA)]
-    [JsonPropertyName("algorithm")]
-    [JsonConverter(typeof(JsonStringEnumCamelCaseConverter))]
-    public SecretVariableProviderAlgorithm Algorithm { get; init; }
-
-    [DefaultValue(EncryptionPadding.OaepSHA256)]
-    [JsonPropertyName("padding")]
-    [JsonConverter(typeof(JsonStringEnumCamelCaseConverter))]
-    public EncryptionPadding Padding { get; init; }
-
-    [JsonPropertyName("publicKey")]
-    public string? PublicKey { get; init; }
-
-    [JsonPropertyName("publicKeyPath")]
-    public string? PublicKeyPath { get; init; }
-
-    [JsonPropertyName("privateKey")]
-    public string? PrivateKey { get; init; }
-
-    [JsonPropertyName("privateKeyPath")]
-    public string? PrivateKeyPath { get; init; }
-
     public static SecretVariableProviderConfiguration Parse(JsonNode node)
     {
         try
         {
-            return node.Deserialize(JsonSerialization.Default.SecretVariableProviderConfiguration)!;
+            return node.Deserialize(JsonSerialization.Instance.SecretVariableProviderConfiguration)!;
         }
         catch (JsonException ex)
         {

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/AzureKeyVaultProviderTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/AzureKeyVaultProviderTests.cs
@@ -84,7 +84,7 @@ public class AzureKeyVaultProviderTests
         AzureKeyVaultProvider provider = new(secretClientMock.Object);
 
         // act
-        var result = await provider.SetAsync("foo", JsonValue.Create("bar"), default);
+        var result = await provider.SetAsync("foo", JsonValue.Create("bar")!, default);
 
         // assert
         result.Should().Be("vault.key");

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/GitVariableProviderConfigurationTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/GitVariableProviderConfigurationTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json.Nodes;
+using ConfiX.Variables;
+using FluentAssertions;
+
+namespace Confix.Tool.Tests;
+
+public class GitVariableProviderConfigurationTests
+{
+
+    [Fact]
+    public void Parse_EmptyObject_ThrowsArgumentException()
+    {
+        // arrange
+        var configuration = JsonNode.Parse("{}")!;
+
+        // act
+        Action act = () => GitVariableProviderConfiguration.Parse(configuration);
+
+        // assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Parse_WithValidConfigurationKey_ReturnsValidObject()
+    {
+        // arrange
+        var configuration = JsonNode.Parse(
+            """
+            {
+                "repositoryUrl": "foo-bar",
+                "FilePath": "some.file"
+            }
+            """
+        )!;
+
+        // act
+        var result = GitVariableProviderConfiguration.Parse(configuration);
+
+        // assert
+        result.Should().Be(new GitVariableProviderConfiguration(
+            "foo-bar", 
+            "some.file"));
+    }
+}

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/JsonVariableRewriterTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/JsonVariableRewriterTests.cs
@@ -30,7 +30,7 @@ public class JsonVariableRewriterTests
             }
         """)!;
         var variableLookup = new Dictionary<VariablePath, JsonNode> {
-            { VariablePath.Parse("$test:variable.string"), JsonValue.Create("someReplacedValue")},
+            { VariablePath.Parse("$test:variable.string"), JsonValue.Create("someReplacedValue")!},
             { VariablePath.Parse("$test:variable.number"), JsonValue.Create(420)},
             { VariablePath.Parse("$test:variable.bool"), JsonValue.Create(true)},
             { VariablePath.Parse("$test:variable.array"), JsonNode.Parse("""["a", "b", "c"]""")!},

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/LocalVariableProviderConfigurationTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/LocalVariableProviderConfigurationTests.cs
@@ -21,7 +21,7 @@ public class LocalVariableProviderConfigurationTests
         var config = LocalVariableProviderConfiguration.Parse(jsonNode);
 
         // Assert
-        config.FilePath.Should().Be("/path/to/file.json");
+        config.Path.Should().Be("/path/to/file.json");
     }
 
     [Fact]

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/LocalVariableProviderTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/LocalVariableProviderTests.cs
@@ -20,7 +20,7 @@ public class LocalVariableProviderTests : IDisposable
                 "bar": "baz"
             }
             """);
-        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration() { FilePath = tmpFilePath });
+        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration(tmpFilePath));
 
         // act
         var result = await provider.ListAsync(default);
@@ -42,7 +42,7 @@ public class LocalVariableProviderTests : IDisposable
                 "bar": "baz"
             }
             """);
-        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration() { FilePath = tmpFilePath });
+        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration(tmpFilePath));
 
         // act
         var result = await provider.ResolveAsync("foo", default);
@@ -61,7 +61,7 @@ public class LocalVariableProviderTests : IDisposable
                 "someArray": ["a", "b", "c"]
             }
             """);
-        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration() { FilePath = tmpFilePath });
+        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration(tmpFilePath));
 
         // act
         var result = await provider.ResolveAsync("someArray", default);
@@ -81,7 +81,7 @@ public class LocalVariableProviderTests : IDisposable
                 "bar": "baz"
             }
             """);
-        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration() { FilePath = tmpFilePath });
+        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration(tmpFilePath));
 
         // act & assert
         await Assert.ThrowsAsync<VariableNotFoundException>(() => provider.ResolveAsync("nonexistent", default));
@@ -98,7 +98,7 @@ public class LocalVariableProviderTests : IDisposable
                 "bar": "baz"
             }
             """);
-        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration() { FilePath = tmpFilePath });
+        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration(tmpFilePath));
         var paths = new List<string> { "foo", "bar" };
 
         // act
@@ -120,7 +120,7 @@ public class LocalVariableProviderTests : IDisposable
                 "bar": "baz"
             }
             """);
-        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration() { FilePath = tmpFilePath });
+        LocalVariableProvider provider = new(new LocalVariableProviderConfiguration(tmpFilePath));
         var paths = new List<string> { "foo", "nonexistent" };
 
         // act & assert

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/SecretVariableProviderConfigurationTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/SecretVariableProviderConfigurationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using ConfiX.Variables;
 using FluentAssertions;
+using Snapshooter.Xunit;
 
 namespace Confix.Tool.Tests;
 
@@ -17,10 +18,7 @@ public class SecretVariableProviderConfigurationTests
         var result = SecretVariableProviderConfiguration.Parse(configuration);
 
         // assert
-        result.Should().Be(new SecretVariableProviderConfiguration
-        {
-            Algorithm = SecretVariableProviderAlgorithm.RSA,
-        });
+        result.Should().MatchSnapshot();
     }
 
     [Fact]
@@ -41,12 +39,7 @@ public class SecretVariableProviderConfigurationTests
         var result = SecretVariableProviderConfiguration.Parse(configuration);
 
         // assert
-        result.Should().Be(new SecretVariableProviderConfiguration
-        {
-            Algorithm = SecretVariableProviderAlgorithm.RSA,
-            PublicKey = "SomePublicKey",
-            PrivateKey = "SomePrivateKey",
-        });
+        result.Should().MatchSnapshot();
     }
 
     [Fact]
@@ -67,11 +60,6 @@ public class SecretVariableProviderConfigurationTests
         var result = SecretVariableProviderConfiguration.Parse(configuration);
 
         // assert
-        result.Should().Be(new SecretVariableProviderConfiguration
-        {
-            Algorithm = SecretVariableProviderAlgorithm.RSA,
-            PublicKeyPath = "./pub.pem",
-            PrivateKeyPath = "./priv.pem",
-        });
+        result.Should().MatchSnapshot();
     }
 }

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/SecretVariableProviderTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/SecretVariableProviderTests.cs
@@ -38,10 +38,14 @@ public class SecretVariableProviderTests
     public async Task ListAsync_IsNonSense_ReturnsEmptyArrayAsync()
     {
         // arrange
-        SecretVariableProvider provider = new(new SecretVariableProviderConfiguration
-        {
-            Algorithm = SecretVariableProviderAlgorithm.RSA,
-        });
+        SecretVariableProvider provider = new(new SecretVariableProviderConfiguration(
+            SecretVariableProviderAlgorithm.RSA,
+            EncryptionPadding.OaepSHA256,
+            null,
+            null,
+            null,
+            null)
+        );
 
         // act
         var result = await provider.ListAsync(default);
@@ -56,12 +60,15 @@ public class SecretVariableProviderTests
     public async Task ResolveAsync_Should_Decrypt(object value)
     {
         // arrange
-        SecretVariableProvider provider = new(new SecretVariableProviderConfiguration
-        {
-            Algorithm = SecretVariableProviderAlgorithm.RSA,
-            PublicKey = PUBLIC_KEY,
-            PrivateKey = PRIVATE_KEY,
-        });
+        SecretVariableProvider provider = new(new SecretVariableProviderConfiguration(
+            SecretVariableProviderAlgorithm.RSA,
+            EncryptionPadding.OaepSHA256,
+            PUBLIC_KEY,
+            null,
+            PRIVATE_KEY,
+            null)
+        );
+
         var initialSecret = JsonValue.Create(value)!;
         var encryptedSecret = await provider.SetAsync("not relevant here", initialSecret, default);
 

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariableReplacerServiceTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariableReplacerServiceTests.cs
@@ -29,7 +29,7 @@ public class VariableReplacerServiceTests
                 var result = new Dictionary<VariablePath, JsonNode>();
                 foreach (var key in keys)
                 {
-                    result[key] = JsonValue.Create("Replaced Value of " + key);
+                    result[key] = JsonValue.Create("Replaced Value of " + key)!;
                 }
                 return result;
             });

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariableResolverTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariableResolverTests.cs
@@ -54,8 +54,8 @@ public class VariableResolverTests
             cancellationToken))
             .ReturnsAsync(new Dictionary<string, JsonNode>
             {
-                { "Key1", JsonValue.Create("Value1") },
-                { "Key3", JsonValue.Create("Value3") }
+                { "Key1", JsonValue.Create("Value1")! },
+                { "Key3", JsonValue.Create("Value3")! }
             });
 
         var provider2Mock = new Mock<IVariableProvider>();
@@ -64,8 +64,8 @@ public class VariableResolverTests
             cancellationToken))
             .ReturnsAsync(new Dictionary<string, JsonNode>
             {
-                { "Key2", JsonValue.Create("Value2") },
-                { "Key4", JsonValue.Create("Value4") }
+                { "Key2", JsonValue.Create("Value2")! },
+                { "Key4", JsonValue.Create("Value4")! }
             });
 
         factoryMock.Setup(f => f.CreateProvider(configurations[0]))
@@ -119,7 +119,7 @@ public class VariableResolverTests
             cancellationToken))
             .ReturnsAsync(new Dictionary<string, JsonNode>
             {
-                { "Key1", JsonValue.Create("Value1") },
+                { "Key1", JsonValue.Create("Value1")! },
             });
 
         factoryMock.Setup(f => f.CreateProvider(configurations[0]))
@@ -180,7 +180,7 @@ public class VariableResolverTests
             cancellationToken))
             .ReturnsAsync(new Dictionary<string, JsonNode>
             {
-                { "Key1", JsonValue.Create(new VariablePath("Provider2", "Key2").ToString())},
+                { "Key1", JsonValue.Create(new VariablePath("Provider2", "Key2").ToString())!},
             });
 
         var provider2Mock = new Mock<IVariableProvider>();
@@ -189,7 +189,7 @@ public class VariableResolverTests
             cancellationToken))
             .ReturnsAsync(new Dictionary<string, JsonNode>
             {
-                { "Key2", JsonValue.Create("FinalResult" ) },
+                { "Key2", JsonValue.Create("FinalResult")! },
             });
 
         factoryMock.Setup(f => f.CreateProvider(configurations[0]))

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/SecretVariableProviderConfigurationTests.Parse_EmptyObject_DefaultAlgorithm.snap
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/SecretVariableProviderConfigurationTests.Parse_EmptyObject_DefaultAlgorithm.snap
@@ -1,0 +1,8 @@
+﻿{
+  "Algorithm": "RSA",
+  "Padding": "OaepSHA256",
+  "PublicKey": null,
+  "PublicKeyPath": null,
+  "PrivateKey": null,
+  "PrivateKeyPath": null
+}

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/SecretVariableProviderConfigurationTests.Parse_WithValidConfigurationKey_ReturnsValidObject.snap
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/SecretVariableProviderConfigurationTests.Parse_WithValidConfigurationKey_ReturnsValidObject.snap
@@ -1,0 +1,8 @@
+﻿{
+  "Algorithm": "RSA",
+  "Padding": "OaepSHA256",
+  "PublicKey": "SomePublicKey",
+  "PublicKeyPath": null,
+  "PrivateKey": "SomePrivateKey",
+  "PrivateKeyPath": null
+}

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/SecretVariableProviderConfigurationTests.Parse_WithValidConfigurationPath_ReturnsValidObject.snap
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/SecretVariableProviderConfigurationTests.Parse_WithValidConfigurationPath_ReturnsValidObject.snap
@@ -1,0 +1,8 @@
+﻿{
+  "Algorithm": "RSA",
+  "Padding": "OaepSHA256",
+  "PublicKey": null,
+  "PublicKeyPath": "./pub.pem",
+  "PrivateKey": null,
+  "PrivateKeyPath": "./priv.pem"
+}

--- a/src/Confix.Tool/test/Directory.Build.props
+++ b/src/Confix.Tool/test/Directory.Build.props
@@ -2,7 +2,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Confix.Tool/test/Directory.Build.props
+++ b/src/Confix.Tool/test/Directory.Build.props
@@ -2,10 +2,6 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>


### PR DESCRIPTION
- target net7 and net8
- fix compiler warnings
- adapt pipelines to multitarget
- VariableProviderConfiguration 
  - required keyword converted to Attribute since source generator is otherwise broken (init only props not supported) 