### PR TITLE
Support Variables with suffix

### DIFF
--- a/docs/components/logo.tsx
+++ b/docs/components/logo.tsx
@@ -25,8 +25,8 @@ export const Logo: React.FC<SVGProps<SVGSVGElement>> = (props) => (
     <path
       fill="none"
       stroke="currentColor"
-      stroke-miterlimit="10"
-      stroke-width="5"
+      strokeMiterlimit="10"
+      strokeWidth="5"
       d="m104.01 138.43-10.86 6-10.86-6v-12l10.86-6 10.86 6v12z"
     ></path>
     <path

--- a/docs/components/logo.tsx
+++ b/docs/components/logo.tsx
@@ -15,8 +15,8 @@ export const Logo: React.FC<SVGProps<SVGSVGElement>> = (props) => (
         y2="132.32"
         gradientUnits="userSpaceOnUse"
       >
-        <stop offset="0" stop-color="#7dcdee"></stop>
-        <stop offset="1" stop-color="#189cd9"></stop>
+        <stop offset="0" stopColor="#7dcdee"></stop>
+        <stop offset="1" stopColor="#189cd9"></stop>
       </linearGradient>
     </defs>
     <path fill="#189cd9" d="m93.15 121.03-10.86 6v12l10.86 6v-24z"></path>

--- a/docs/pages/variables.mdx
+++ b/docs/pages/variables.mdx
@@ -2,7 +2,7 @@
 
 Confix has the concept of variables. These variables are typically used to reference secrets, or any configuration data that should not be directly entered into the configuration files. They can be used for values are not known at development time.
 
-In Confix, variables have a distinct structure: `$providerName:path.to.resource`, where `providerName` refers to the source or provider of the variable value, and `path.to.resource` indicates the specific resource or secret in the provider's repository. Optionally a suffix can be added (eg. `$providerName:path.to.resource:mySuffix`). This might be useful for storing base paths in variables.
+In Confix, variables have a distinct structure: `$providerName:path.to.resource`, where `providerName` refers to the source or provider of the variable value, and `path.to.resource` indicates the specific resource or secret in the provider's repository. Variables may be nested in strings. in that case the variable must be placed within double curly braces like `{{$provider:path.to.resource}}`.
 
 Variables are resolved during the `build` operation of the configuration. This operation can take place at various stages of your development lifecycle. You can also `validate` your configuration against a specific environment to ensure that all variables can be resolved before deployment. For more on this, see the `Deploying your App` section.
 
@@ -98,7 +98,7 @@ Here's an example JSON configuration file that uses Confix variables:
     "jwtSecret": "$vault:jwt.secret"
   },
   "clients": {
-    "baseUrl": "$keyvault:api.baseUrl:/my-endpoint"
+    "baseUrl": "{{$keyvault:api.baseUrl}}/my-endpoint"
   }
 }
 ```

--- a/docs/pages/variables.mdx
+++ b/docs/pages/variables.mdx
@@ -2,7 +2,7 @@
 
 Confix has the concept of variables. These variables are typically used to reference secrets, or any configuration data that should not be directly entered into the configuration files. They can be used for values are not known at development time.
 
-In Confix, variables have a distinct structure: `$providerName:path.to.resource`, where `providerName` refers to the source or provider of the variable value, and `path.to.resource` indicates the specific resource or secret in the provider's repository.
+In Confix, variables have a distinct structure: `$providerName:path.to.resource`, where `providerName` refers to the source or provider of the variable value, and `path.to.resource` indicates the specific resource or secret in the provider's repository. Optionally a suffix can be added (eg. `$providerName:path.to.resource:mySuffix`). This might be useful for storing base paths in variables.
 
 Variables are resolved during the `build` operation of the configuration. This operation can take place at various stages of your development lifecycle. You can also `validate` your configuration against a specific environment to ensure that all variables can be resolved before deployment. For more on this, see the `Deploying your App` section.
 
@@ -96,6 +96,9 @@ Here's an example JSON configuration file that uses Confix variables:
   "appSecrets": {
     "apiKey": "$secret:aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1hM1o3ekVjN0FYUQ==",
     "jwtSecret": "$vault:jwt.secret"
+  },
+  "clients": {
+    "baseUrl": "$keyvault:api.baseUrl:/my-endpoint"
   }
 }
 ```

--- a/src/Confix.Tool/src/Confix.Tool/Pipelines/Variable/VariableSetPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Pipelines/Variable/VariableSetPipeline.cs
@@ -28,11 +28,15 @@ public sealed class VariableSetPipeline : Pipeline
 
         if (VariablePath.TryParse(variableName, out var parsed))
         {
+            if (parsed.Value.Suffix is not null)
+            {
+                throw new ExitException("Variable suffix is not supported while setting variable.");
+            }
             var result = await resolver
                 .SetVariable(
                     parsed.Value.ProviderName,
                     parsed.Value.Path,
-                    JsonValue.Create(variableValue),
+                    JsonValue.Create(variableValue)!,
                     context.CancellationToken);
 
             context.Logger.VariableSet(result);

--- a/src/Confix.Tool/src/Confix.Tool/Pipelines/Variable/VariableSetPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Pipelines/Variable/VariableSetPipeline.cs
@@ -28,10 +28,6 @@ public sealed class VariableSetPipeline : Pipeline
 
         if (VariablePath.TryParse(variableName, out var parsed))
         {
-            if (parsed.Value.Suffix is not null)
-            {
-                throw new ExitException("Variable suffix is not supported while setting variable.");
-            }
             var result = await resolver
                 .SetVariable(
                     parsed.Value.ProviderName,

--- a/src/Confix.Tool/src/Confix.Tool/Variables/JsonVariableRewriter.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/JsonVariableRewriter.cs
@@ -20,21 +20,12 @@ public sealed class JsonVariableRewriter : JsonDocumentRewriter<JsonVariableRewr
     {
         if (VariablePath.TryParse(key, out VariablePath? parsed))
         {
-            var resolved = context.VariableLookup[parsed.Value with { Suffix = null }];
-            if (parsed.Value.Suffix is null)
-            {
-                return resolved.Copy()!;
-            }
-            else if (resolved.GetSchemaValueType() == SchemaValueType.String)
-            {
-                return JsonValue.Create(((string)resolved!) + parsed.Value.Suffix)!;
-            }
-            else
-            {
-                throw new ExitException("Cannot append suffix to non-string variable");
-            }
+            return context.VariableLookup[parsed.Value].Copy()!;
         }
 
-        return JsonValue.Create(key)!;
+        var replacedString = key.ReplaceVariables(v => context.VariableLookup[v].ToString());
+        return JsonValue.Create(replacedString)!;
     }
+
+  
 }

--- a/src/Confix.Tool/src/Confix.Tool/Variables/VariablePath.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/VariablePath.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ConfiX.Variables;
 
-public readonly record struct VariablePath(string ProviderName, string Path)
+public readonly record struct VariablePath(string ProviderName, string Path, string? Suffix = null)
 {
     public static VariablePath Parse(string variable)
     {
@@ -16,15 +16,20 @@ public readonly record struct VariablePath(string ProviderName, string Path)
     public static bool TryParse(string variable, [NotNullWhen(true)]out VariablePath? parsed)
     {
         var split = variable.Split(':') ?? Array.Empty<string>();
-        if (!variable.StartsWith('$') || split.Length != 2)
+        if (!variable.StartsWith('$') || split.Length < 2)
         {
             parsed = null;
             return false;
         }
 
         parsed = new VariablePath(split[0].Remove(0, 1), split[1]);
+
+        if(split.Length > 2)
+        {
+            parsed = parsed.Value with { Suffix = string.Join(':', split.Skip(2)) };
+        }
         return true;
     }
 
-    public override string ToString() => $"${ProviderName}:{Path}";
+    public override string ToString() => $"${ProviderName}:{Path}{(Suffix is not null ? $":{Suffix}" : "")}";
 }

--- a/src/Confix.Tool/src/Confix.Tool/Variables/VariablePath.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/VariablePath.cs
@@ -1,8 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 
 namespace ConfiX.Variables;
 
-public readonly record struct VariablePath(string ProviderName, string Path, string? Suffix = null)
+public partial record struct VariablePath(string ProviderName, string Path)
 {
     public static VariablePath Parse(string variable)
     {
@@ -13,23 +14,46 @@ public readonly record struct VariablePath(string ProviderName, string Path, str
         throw new VariablePathParseException(variable);
     }
 
-    public static bool TryParse(string variable, [NotNullWhen(true)]out VariablePath? parsed)
+    public static bool TryParse(string variable, [NotNullWhen(true)] out VariablePath? parsed)
     {
-        var split = variable.Split(':') ?? Array.Empty<string>();
-        if (!variable.StartsWith('$') || split.Length < 2)
+        Match x = VariableNameRegex().Match(variable);
+        if (!x.Success)
         {
             parsed = null;
             return false;
         }
 
-        parsed = new VariablePath(split[0].Remove(0, 1), split[1]);
-
-        if(split.Length > 2)
-        {
-            parsed = parsed.Value with { Suffix = string.Join(':', split.Skip(2)) };
-        }
+        parsed = new VariablePath(
+            x.Groups[VariableProviderCaptureGroup].Value,
+            x.Groups[VariableNameCaptureGroup].Value);
         return true;
     }
 
-    public override string ToString() => $"${ProviderName}:{Path}{(Suffix is not null ? $":{Suffix}" : "")}";
+    public override string ToString() => $"${ProviderName}:{Path}";
+
+    private const string VariableProviderCaptureGroup = "VariableProvider";
+    private const string VariableNameCaptureGroup = "VariableName";
+
+    [GeneratedRegex($$"""^\$(?<{{VariableProviderCaptureGroup}}>[\w\.]+):(?<{{VariableNameCaptureGroup}}>[\w\.]+)$""")]
+    private static partial Regex VariableNameRegex();
+}
+
+public static partial class VariablePathExtensions
+{
+    public static IEnumerable<VariablePath> GetVariables(this string value)
+    => MultipleInterpolatedVariablesRegex()
+        .Matches(value)
+        .Select(match => VariablePath.Parse(match.Groups[VariableCaptureGroup].Value));
+
+    public static string ReplaceVariables(this string value, Func<VariablePath, string> replacer)
+    => MultipleInterpolatedVariablesRegex().Replace(value, match =>
+        {
+            var parsed = VariablePath.Parse(match.Groups[VariableCaptureGroup].Value);
+            return replacer(parsed);
+        });
+
+    private const string VariableCaptureGroup = "variable";
+
+    [GeneratedRegex($$"""(\{\{)?(?<{{VariableCaptureGroup}}>\$(?:[\w\.]+):(?:[\w\.]+))(\}\})?""")]
+    private static partial Regex MultipleInterpolatedVariablesRegex();
 }

--- a/src/Confix.Tool/src/Confix.Tool/Variables/VariableReplacerService.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Variables/VariableReplacerService.cs
@@ -29,17 +29,9 @@ public sealed class VariableReplacerService : IVariableReplacerService
     }
 
     private static IEnumerable<VariablePath> GetVariables(JsonNode node)
-    {
-        foreach (var value in JsonParser.ParseNode(node).Values)
-        {
-            if (
-                value?.GetSchemaValueType() == SchemaValueType.String
-                && VariablePath.TryParse(value.ToString(), out var parsed))
-            {
-                yield return parsed.Value;
-            }
-        }
-    }
+        => JsonParser.ParseNode(node).Values
+            .Where(v => v.GetSchemaValueType() == SchemaValueType.String)
+            .SelectMany(v => v!.ToString().GetVariables());
 }
 
 file static class LogExtensionts

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/JsonVariableRewriterTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/JsonVariableRewriterTests.cs
@@ -42,4 +42,24 @@ public class JsonVariableRewriterTests
         // assert
         result?.ToString().MatchSnapshot();
     }
+
+    [Fact]
+    public void Rewrite_ShouldReplaceAllVarsWithSuffix()
+    {
+        // arrange
+        JsonNode node = JsonNode.Parse("""
+            {
+                "test": "$test:variable.string:/someSuffix"
+            }
+        """)!;
+        var variableLookup = new Dictionary<VariablePath, JsonNode> {
+            { VariablePath.Parse("$test:variable.string"), JsonValue.Create("someReplacedValue")!},
+        };
+
+        // act
+        var result = new JsonVariableRewriter().Rewrite(node, new(variableLookup));
+
+        // assert
+        result?.ToString().MatchSnapshot();
+    }
 }

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/JsonVariableRewriterTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/JsonVariableRewriterTests.cs
@@ -18,6 +18,7 @@ public class JsonVariableRewriterTests
                 },
                 "bar": ["$test:variable.string"],
                 "number": 42,
+                "stringWithMultiple": "asterix-{{$test:variable.bool}}-oberlix-midefix-{{$test:variable.string}}-confix",
                 "bool": "$test:variable.bool",
                 "array": "$test:variable.array",
                 "arrayElement": [
@@ -34,26 +35,6 @@ public class JsonVariableRewriterTests
             { VariablePath.Parse("$test:variable.number"), JsonValue.Create(420)},
             { VariablePath.Parse("$test:variable.bool"), JsonValue.Create(true)},
             { VariablePath.Parse("$test:variable.array"), JsonNode.Parse("""["a", "b", "c"]""")!},
-        };
-
-        // act
-        var result = new JsonVariableRewriter().Rewrite(node, new(variableLookup));
-
-        // assert
-        result?.ToString().MatchSnapshot();
-    }
-
-    [Fact]
-    public void Rewrite_ShouldReplaceAllVarsWithSuffix()
-    {
-        // arrange
-        JsonNode node = JsonNode.Parse("""
-            {
-                "test": "$test:variable.string:/someSuffix"
-            }
-        """)!;
-        var variableLookup = new Dictionary<VariablePath, JsonNode> {
-            { VariablePath.Parse("$test:variable.string"), JsonValue.Create("someReplacedValue")!},
         };
 
         // act

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariablePathTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariablePathTests.cs
@@ -4,19 +4,24 @@ namespace Confix.Tool.Tests;
 
 public class VariablePathTests
 {
-    [Fact]
-    public void Parse_ValidVariableName_CorrectResult()
+    [Theory]
+    [InlineData("$foo:bar", "foo", "bar", null)]
+    [InlineData("$foo:bar:baz", "foo", "bar", "baz")]
+    [InlineData("$foo.bar:baz.x", "foo.bar", "baz.x", null)]
+    [InlineData("$foo.bar:baz.x:suffix", "foo.bar", "baz.x", "suffix")]
+    [InlineData("$foo.bar:baz.x:suffix:with:colon", "foo.bar", "baz.x", "suffix:with:colon")]
+    public void Parse_ValidVariableName_CorrectResult(string variableName, string providerName, string path, string? suffix)
     {
         // arrange & act
-        VariablePath result = VariablePath.Parse("$foo.bar:baz.x");
+        VariablePath result = VariablePath.Parse(variableName);
 
         // assert
-        result.ProviderName.Should().Be("foo.bar");
-        result.Path.Should().Be("baz.x");
+        result.ProviderName.Should().Be(providerName);
+        result.Path.Should().Be(path);
+        result.Suffix.Should().Be(suffix);
     }
 
     [Theory]
-    [InlineData("$foo:bar:baz")]
     [InlineData("bar")]
     [InlineData("$foo.bar")]
     [InlineData("foo:bar")]
@@ -37,10 +42,10 @@ public class VariablePathTests
         path.HasValue.Should().BeTrue();
         path!.Value.ProviderName.Should().Be("foo.bar");
         path!.Value.Path.Should().Be("baz.x");
+        path!.Value.Suffix.Should().BeNull();
     }
 
     [Theory]
-    [InlineData("$foo:bar:baz")]
     [InlineData("bar")]
     [InlineData("$foo.bar")]
     [InlineData("foo:bar")]

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariablePathTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariablePathTests.cs
@@ -5,12 +5,10 @@ namespace Confix.Tool.Tests;
 public class VariablePathTests
 {
     [Theory]
-    [InlineData("$foo:bar", "foo", "bar", null)]
-    [InlineData("$foo:bar:baz", "foo", "bar", "baz")]
-    [InlineData("$foo.bar:baz.x", "foo.bar", "baz.x", null)]
-    [InlineData("$foo.bar:baz.x:suffix", "foo.bar", "baz.x", "suffix")]
-    [InlineData("$foo.bar:baz.x:suffix:with:colon", "foo.bar", "baz.x", "suffix:with:colon")]
-    public void Parse_ValidVariableName_CorrectResult(string variableName, string providerName, string path, string? suffix)
+    [InlineData("$foo:bar", "foo", "bar")]
+    [InlineData("$foo.bar:baz.x", "foo.bar", "baz.x")]
+    [InlineData("$foo_bar:baz_x", "foo_bar", "baz_x")]
+    public void Parse_ValidVariableName_CorrectResult(string variableName, string providerName, string path)
     {
         // arrange & act
         VariablePath result = VariablePath.Parse(variableName);
@@ -18,12 +16,12 @@ public class VariablePathTests
         // assert
         result.ProviderName.Should().Be(providerName);
         result.Path.Should().Be(path);
-        result.Suffix.Should().Be(suffix);
     }
 
     [Theory]
     [InlineData("bar")]
     [InlineData("$foo.bar")]
+    [InlineData("$$foo:bar")]
     [InlineData("foo:bar")]
     public void Parse_Invalid_Throws(string variableName)
     {
@@ -42,7 +40,6 @@ public class VariablePathTests
         path.HasValue.Should().BeTrue();
         path!.Value.ProviderName.Should().Be("foo.bar");
         path!.Value.Path.Should().Be("baz.x");
-        path!.Value.Suffix.Should().BeNull();
     }
 
     [Theory]

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariableReplacerServiceTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariableReplacerServiceTests.cs
@@ -15,7 +15,9 @@ public class VariableReplacerServiceTests
             {
                 "foo": {
                     "bar": "baz",
-                    "test": "$test:variable.number"
+                    "test": "$test:variable.number",
+                    "interpolated": "prefix-{{$test:variable.string1}}-suffix",
+                    "interpolatedMultiple": "asterix-{{$test:variable.string2}}-midefix-{{$test:variable.string3}}-suffix"
                 }
             }
         """)!;

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/JsonVariableRewriterTests.Rewrite_ShouldReplaceAllVars.snap
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/JsonVariableRewriterTests.Rewrite_ShouldReplaceAllVars.snap
@@ -7,6 +7,7 @@
     "someReplacedValue"
   ],
   "number": 42,
+  "stringWithMultiple": "asterix-true-oberlix-midefix-someReplacedValue-confix",
   "bool": true,
   "array": [
     "a",

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/JsonVariableRewriterTests.Rewrite_ShouldReplaceAllVarsWithSuffix.snap
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/JsonVariableRewriterTests.Rewrite_ShouldReplaceAllVarsWithSuffix.snap
@@ -1,0 +1,3 @@
+﻿{
+  "test": "someReplacedValue/someSuffix"
+}

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/VariableReplacerServiceTests.RewriteAsync_ValidVariables_ReplaceAllVariablesAsync.snap
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/__snapshots__/VariableReplacerServiceTests.RewriteAsync_ValidVariables_ReplaceAllVariablesAsync.snap
@@ -1,6 +1,8 @@
 ﻿{
   "foo": {
     "bar": "baz",
-    "test": "Replaced Value of $test:variable.number"
+    "test": "Replaced Value of $test:variable.number",
+    "interpolated": "prefix-Replaced Value of $test:variable.string1-suffix",
+    "interpolatedMultiple": "asterix-Replaced Value of $test:variable.string2-midefix-Replaced Value of $test:variable.string3-suffix"
   }
 }


### PR DESCRIPTION
A Variable can now be palced inside a string using the following syntax:
`"somePrefix{{$provider:path.to.resource}}somesuffix"`
resolves #84 