### PR TITLE
Added workaround fix for ParameterCollectionExtensions.TryGet

### DIFF
--- a/src/Confix.Tool/src/Confix.Tool/Common/Execution/ParameterCollectionExtensions.cs
+++ b/src/Confix.Tool/src/Confix.Tool/Common/Execution/ParameterCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Parsing;
 
 namespace Confix.Tool.Common.Pipelines;
 
@@ -44,9 +45,17 @@ public static class ParameterCollectionExtensions
         Argument<T> argument,
         out T value)
     {
-        if (collection.TryGet(argument, out object? val) && val is T valueOfT)
+        collection.TryGet(argument, out object? val);
+        
+        if (val is T valueOfT)
         {
             value = valueOfT;
+            return true;
+        }
+        
+        if (val is Token { Type: TokenType.Argument } token)
+        {
+            value = (T)Activator.CreateInstance(typeof(T), token.Value)!;
             return true;
         }
 


### PR DESCRIPTION
The out-file parameter in the parameter collection is always parsed to Token, not FileInfo:
![image](https://github.com/SwissLife-OSS/Confix/assets/6861396/09eed721-9b57-4902-85e7-24cf71fe2005)
This way it was impossible to pass the the parameter as wished:
- confix encrypt input.json output.encrypted 