### PR TITLE
Adds several UX imporvments

### DIFF
--- a/src/Confix.Tool/src/Confix.Library/Common/Pipelines/PipelineExecutor.cs
+++ b/src/Confix.Tool/src/Confix.Library/Common/Pipelines/PipelineExecutor.cs
@@ -90,9 +90,14 @@ public sealed class PipelineExecutor
             Services = _services
         };
 
-        await _pipeline(context);
-
-        await status.StopAsync();
+        try
+        {
+            await _pipeline(context);
+        }
+        finally
+        {
+            await status.StopAsync();
+        }
 
         return context.ExitCode;
     }
@@ -104,6 +109,7 @@ file class NullStatusContext : IStatus
 
     public ValueTask<IAsyncDisposable> PauseAsync(CancellationToken cancellationToken)
         => ValueTask.FromResult<IAsyncDisposable>(this);
+
     public ValueTask StopAsync() => ValueTask.CompletedTask;
 
     /// <inheritdoc />

--- a/src/Confix.Tool/src/Confix.Library/ConfigurationAdapter/ConfigurationAdapterMiddleware.cs
+++ b/src/Confix.Tool/src/Confix.Library/ConfigurationAdapter/ConfigurationAdapterMiddleware.cs
@@ -22,8 +22,8 @@ public sealed class ConfigurationAdapterMiddleware : IMiddleware
         var configuration = context.Features.Get<ConfigurationFeature>();
         if (!configuration.TryGetSolution(out var solutionFile))
         {
-            context.Logger.NoSolutionFileFound();
-            throw new ExitException();
+            throw new ExitException(
+                "No solution file found, could not load VSCode Settings. Please make sure that the current directory is a Confix solution.");
         }
 
         await next(context);
@@ -42,15 +42,6 @@ public sealed class ConfigurationAdapterMiddleware : IMiddleware
         {
             await adapter.UpdateJsonSchemasAsync(adapterContext);
         }
-    }
-}
-
-file static class Logs
-{
-    public static void NoSolutionFileFound(this IConsoleLogger logger)
-    {
-        logger.Error(
-            "No solution file found, could not load VSCode Settings. Please make sure that the current directory is a Confix solution.");
     }
 }
 

--- a/src/Confix.Tool/src/Confix.Library/ConfigurationFile/AppSettings/DotnetConfigurationFileProvider.cs
+++ b/src/Confix.Tool/src/Confix.Library/ConfigurationFile/AppSettings/DotnetConfigurationFileProvider.cs
@@ -20,9 +20,7 @@ public sealed class AppSettingsConfigurationFileProvider : IConfigurationFilePro
         var configuration =
             AppSettingsConfigurationFileProviderConfiguration.Parse(context.Definition.Value);
 
-        var input = context.Project.Directory!.FindInPath(FileNames.AppSettings, false);
-
-        if (input is null)
+        if (context.Project.Directory?.FindInPath(FileNames.AppSettings, false) is not { } input)
         {
             return Array.Empty<ConfigurationFile>();
         }

--- a/src/Confix.Tool/src/Confix.Library/ConfigurationFile/Inline/InlineConfigurationFileProvider.cs
+++ b/src/Confix.Tool/src/Confix.Library/ConfigurationFile/Inline/InlineConfigurationFileProvider.cs
@@ -10,11 +10,16 @@ public sealed class InlineConfigurationFileProvider : IConfigurationFileProvider
 
     public IReadOnlyList<ConfigurationFile> GetConfigurationFiles(IConfigurationFileContext context)
     {
-        var files = new List<ConfigurationFile>();
-
         var path = context.Definition.Value.ExpectValue<string>();
 
-        foreach (var file in context.Project.Directory!.FindAllInPath(path, false))
+        if (context.Project.Directory is not { } directory)
+        {
+            return Array.Empty<ConfigurationFile>();
+        }
+
+        var files = new List<ConfigurationFile>();
+
+        foreach (var file in directory.FindAllInPath(path, false))
         {
             context.Logger.FoundAInlineConfigurationFile(file);
 

--- a/src/Confix.Tool/src/Confix.Library/Entities/Component/Providers/DotNet/DotnetPackageComponentProvider.cs
+++ b/src/Confix.Tool/src/Confix.Library/Entities/Component/Providers/DotNet/DotnetPackageComponentProvider.cs
@@ -35,8 +35,8 @@ public sealed class DotnetPackageComponentProvider : IComponentProvider
         var buildResult = await DotnetHelpers.BuildProjectAsync(csproj, context.CancellationToken);
         if (!buildResult.Succeeded)
         {
-            context.Logger.DotnetProjectBuildFailed(buildResult.Output);
-            throw new ExitException();
+            var output = buildResult.Output.EscapeMarkup();
+            throw new ExitException($"Failed to build project:\n{output}");
         }
 
         var projectAssembly = DotnetHelpers.GetAssemblyFileFromCsproj(csproj);
@@ -276,10 +276,5 @@ file static class Log
     {
         logger.Debug(
             $"Parsing component from resource '{resourceName}' in assembly '{assembly.FullName}'");
-    }
-
-    public static void DotnetProjectBuildFailed(this IConsoleLogger logger, string output)
-    {
-        logger.Error($"Failed to build project:\n{output.EscapeMarkup()}");
     }
 }

--- a/src/Confix.Tool/src/Confix.Library/Pipelines/Component/ComponentInitPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Library/Pipelines/Component/ComponentInitPipeline.cs
@@ -35,8 +35,9 @@ public sealed class ComponentInitPipeline : Pipeline
 
         if (componentFile.Exists)
         {
-            context.Logger.LogComponentAlreadyExists(componentFile);
-            throw new ExitException();
+            var link = componentFile.Directory?.Name.ToLink(componentFile);
+            throw new ExitException(
+                $"Component already exists:{link} [dim]{componentFile.FullName}[/]");
         }
 
         await File
@@ -47,14 +48,6 @@ public sealed class ComponentInitPipeline : Pipeline
 
 file static class Log
 {
-    public static void LogComponentAlreadyExists(
-        this IConsoleLogger console,
-        FileInfo info)
-    {
-        console.Error(
-            $"Component already exists:{info.Directory?.Name.ToLink(info)} [dim]{info.FullName}[/]");
-    }
-
     public static void LogComponentCreated(
         this IConsoleLogger console,
         FileInfo info)

--- a/src/Confix.Tool/src/Confix.Library/Pipelines/ComponentBuildPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Library/Pipelines/ComponentBuildPipeline.cs
@@ -28,9 +28,9 @@ public class ComponentBuildPipeline : Pipeline
         switch (configuration.Scope)
         {
             case ConfigurationScope.None:
-                context.Logger
-                    .LogNoConfixContextWasFound(context.Execution.CurrentDirectory.FullName);
-                throw new ExitException();
+                var directory = context.Execution.CurrentDirectory.FullName;
+                throw new ExitException(
+                    $"No confix context was found in the executing directory: [yellow]{directory}[/]");
 
             case ConfigurationScope.Component:
             {
@@ -68,16 +68,5 @@ public class ComponentBuildPipeline : Pipeline
             default:
                 throw new ArgumentOutOfRangeException();
         }
-    }
-}
-
-file static class Log
-{
-    public static void LogNoConfixContextWasFound(
-        this IConsoleLogger console,
-        string directory)
-    {
-        console.Error(
-            $"No confix context was found in the executing directory: [yellow]{directory}[/]");
     }
 }

--- a/src/Confix.Tool/src/Confix.Library/Pipelines/ReloadCommandPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Library/Pipelines/ReloadCommandPipeline.cs
@@ -26,13 +26,13 @@ public sealed class ReloadCommandPipeline : Pipeline
         switch (configuration.Scope)
         {
             case ConfigurationScope.None:
-                context.Logger
-                    .LogNoConfixContextWasFound(context.Execution.CurrentDirectory.FullName);
-                throw new ExitException();
+                var directory = context.Execution.CurrentDirectory.FullName;
+                throw new ExitException(
+                    $"No confix context was found in the executing directory: [yellow]{directory}[/]");
 
             case ConfigurationScope.Component:
-                App.Log.ComponentsDoNotSupportReload();
-                throw new ExitException();
+                throw new ExitException(
+                    "Components do not support reload. `reload` only works for projects and solutions.");
 
             case ConfigurationScope.Project:
             {
@@ -61,22 +61,5 @@ public sealed class ReloadCommandPipeline : Pipeline
             default:
                 throw new ArgumentOutOfRangeException();
         }
-    }
-}
-
-file static class Log
-{
-    public static void LogNoConfixContextWasFound(
-        this IConsoleLogger console,
-        string directory)
-    {
-        console.Error(
-            $"No confix context was found in the executing directory: [yellow]{directory}[/]");
-    }
-
-    public static void ComponentsDoNotSupportReload(this IConsoleLogger console)
-    {
-        console.Error(
-            "Components do not support reload. `reload` only works for projects and solutions.");
     }
 }

--- a/src/Confix.Tool/src/Confix.Library/Pipelines/Solution/SolutionInitPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Library/Pipelines/Solution/SolutionInitPipeline.cs
@@ -22,8 +22,9 @@ public sealed class SolutionInitPipeline : Pipeline
 
         if (solutionFile.Exists)
         {
-            context.Logger.LogSolutionAlreadyExists(solutionFile);
-            throw new ExitException();
+            var info = solutionFile.Directory?.Name.ToLink(solutionFile);
+            throw new ExitException(
+                $"Solution already exists: {info} [dim]{solutionFile.FullName}[/]");
         }
 
         await File.WriteAllTextAsync(solutionFile.FullName, "{}");
@@ -33,14 +34,6 @@ public sealed class SolutionInitPipeline : Pipeline
 
 file static class Log
 {
-    public static void LogSolutionAlreadyExists(
-        this IConsoleLogger console,
-        FileInfo info)
-    {
-        console.Error(
-            $"Solution already exists: {info.Directory?.Name.ToLink(info)} [dim]{info.FullName}[/]");
-    }
-
     public static void LogSolutionCreated(
         this IConsoleLogger console,
         FileInfo info)

--- a/src/Confix.Tool/src/Confix.Library/Pipelines/ValidateCommandPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Library/Pipelines/ValidateCommandPipeline.cs
@@ -26,13 +26,13 @@ public sealed class ValidateCommandPipeline : Pipeline
         switch (configuration.Scope)
         {
             case ConfigurationScope.None:
-                context.Logger
-                    .LogNoConfixContextWasFound(context.Execution.CurrentDirectory.FullName);
-                throw new ExitException();
+                var directory = context.Execution.CurrentDirectory.FullName;
+                throw new ExitException(
+                    $"No confix context was found in the executing directory: [yellow]{directory}[/]");
 
             case ConfigurationScope.Component:
-                App.Log.ComponentsDoNotSupportValidate();
-                throw new ExitException();
+                throw new ExitException(
+                    "Components do not support reload. `reload` only works for projects and solutions.");
 
             case ConfigurationScope.Project:
             {
@@ -61,22 +61,5 @@ public sealed class ValidateCommandPipeline : Pipeline
             default:
                 throw new ArgumentOutOfRangeException();
         }
-    }
-}
-
-file static class Log
-{
-    public static void LogNoConfixContextWasFound(
-        this IConsoleLogger console,
-        string directory)
-    {
-        console.Error(
-            $"No confix context was found in the executing directory: [yellow]{directory}[/]");
-    }
-
-    public static void ComponentsDoNotSupportValidate(this IConsoleLogger console)
-    {
-        console.Error(
-            "Components do not support reload. `reload` only works for projects and solutions.");
     }
 }

--- a/src/Confix.Tool/src/Confix.Library/Utilities/Console/ExitException.cs
+++ b/src/Confix.Tool/src/Confix.Library/Utilities/Console/ExitException.cs
@@ -2,10 +2,6 @@ namespace Confix.Tool;
 
 internal sealed class ExitException : Exception
 {
-    public ExitException()
-    {
-    }
-
     public ExitException(string message)
         : base(message)
     {

--- a/src/Confix.Tool/src/Confix.Library/Utilities/FileSystem/DirectoryExtensions.cs
+++ b/src/Confix.Tool/src/Confix.Library/Utilities/FileSystem/DirectoryExtensions.cs
@@ -3,30 +3,39 @@ namespace Confix.Tool.Commands.Temp;
 public static class DirectoryExtensions
 {
     public static FileInfo? FindInPath(
-        this DirectoryInfo directory,
+        this DirectoryInfo? directory,
         string fileName,
         bool recursive = true)
-        => Directory
-            .EnumerateFiles(
-                directory.FullName,
-                fileName,
-                recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
-            .Select(x => new FileInfo(x))
-            .FirstOrDefault();
+        => directory is not null
+            ? Directory
+                .EnumerateFiles(
+                    directory.FullName,
+                    fileName,
+                    recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
+                .Select(x => new FileInfo(x))
+                .FirstOrDefault()
+            : null;
 
     public static IEnumerable<FileInfo> FindAllInPath(
-        this DirectoryInfo directory,
+        this DirectoryInfo? directory,
         string pattern,
         bool recursive = true)
-        => Directory
-            .EnumerateFiles(
-                directory.FullName,
-                pattern,
-                recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
-            .Select(x => new FileInfo(x));
+        => directory is not null
+            ? Directory
+                .EnumerateFiles(
+                    directory.FullName,
+                    pattern,
+                    recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
+                .Select(x => new FileInfo(x))
+            : Array.Empty<FileInfo>();
 
-    public static string? FindInTree(this DirectoryInfo directory, string fileName)
+    public static string? FindInTree(this DirectoryInfo? directory, string fileName)
     {
+        if (directory is null)
+        {
+            return null;
+        }
+
         if (!directory.Exists)
         {
             throw new DirectoryNotFoundException($"The directory '{directory}' was not found.");


### PR DESCRIPTION
- Avoid thorwing null reference exception when executing a command like confix project validate when not executed inside the right scope (e.g. a solution folder)

- Avoid printing Exception of type 'Confix.Tool.ExitException' was thrown. (removing the empty message parameter)

- Stop status also on exception
![image](https://github.com/SwissLife-OSS/Confix/assets/14233220/ca8818ed-b4ab-4eab-b209-c46d7402ba68)
vs
![image](https://github.com/SwissLife-OSS/Confix/assets/14233220/aa30fb43-773b-4a2a-a99a-704587f727a5)

