### PR TITLE
Removes the xml declaration header and prettifies the csproj

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.5.23303.2",
+    "version": "8.0.100-preview.7.23376.3",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Confix.Tool/src/Confix.Library/ConfigurationFile/AppSettings/DotnetConfigurationFileProvider.cs
+++ b/src/Confix.Tool/src/Confix.Library/ConfigurationFile/AppSettings/DotnetConfigurationFileProvider.cs
@@ -13,7 +13,9 @@ public sealed class AppSettingsConfigurationFileProvider : IConfigurationFilePro
 {
     public static string Type => "appsettings";
 
-    public IReadOnlyList<ConfigurationFile> GetConfigurationFiles(IConfigurationFileContext context)
+    public async Task<IReadOnlyList<ConfigurationFile>> GetConfigurationFilesAsync(
+        IConfigurationFileContext context,
+        CancellationToken ct)
     {
         var files = new List<ConfigurationFile>();
 
@@ -33,7 +35,7 @@ public sealed class AppSettingsConfigurationFileProvider : IConfigurationFilePro
             var csproj = DotnetHelpers.FindProjectFileInPath(context.Project.Directory!);
             if (csproj is not null)
             {
-                var userSecretsId = DotnetHelpers.EnsureUserSecretsId(csproj);
+                var userSecretsId = await DotnetHelpers.EnsureUserSecretsIdAsync(csproj, ct);
                 var userSecretsFolder = GetUserSecretPath(userSecretsId);
                 output = new FileInfo(Path.Combine(userSecretsFolder.FullName, FileNames.Secrets));
                 context.Logger.UseUserSecretsConfigurationFile(output);

--- a/src/Confix.Tool/src/Confix.Library/ConfigurationFile/IConfigurationFileProvider.cs
+++ b/src/Confix.Tool/src/Confix.Library/ConfigurationFile/IConfigurationFileProvider.cs
@@ -8,5 +8,7 @@ public interface IConfigurationFileProvider
 {
     public static virtual string Type => string.Empty;
     
-    IReadOnlyList<ConfigurationFile> GetConfigurationFiles(IConfigurationFileContext context);
+    Task<IReadOnlyList<ConfigurationFile>> GetConfigurationFilesAsync(
+        IConfigurationFileContext context,
+        CancellationToken ct);
 }

--- a/src/Confix.Tool/src/Confix.Library/ConfigurationFile/Inline/InlineConfigurationFileProvider.cs
+++ b/src/Confix.Tool/src/Confix.Library/ConfigurationFile/Inline/InlineConfigurationFileProvider.cs
@@ -8,13 +8,16 @@ public sealed class InlineConfigurationFileProvider : IConfigurationFileProvider
 {
     public static string Type => "inline";
 
-    public IReadOnlyList<ConfigurationFile> GetConfigurationFiles(IConfigurationFileContext context)
+    public Task<IReadOnlyList<ConfigurationFile>> GetConfigurationFilesAsync(
+        IConfigurationFileContext context,
+        CancellationToken ct)
     {
         var path = context.Definition.Value.ExpectValue<string>();
 
         if (context.Project.Directory is not { } directory)
         {
-            return Array.Empty<ConfigurationFile>();
+            return Task.FromResult<IReadOnlyList<ConfigurationFile>>(
+                Array.Empty<ConfigurationFile>());
         }
 
         var files = new List<ConfigurationFile>();
@@ -26,7 +29,7 @@ public sealed class InlineConfigurationFileProvider : IConfigurationFileProvider
             files.Add(new ConfigurationFile { InputFile = file, OutputFile = file });
         }
 
-        return files;
+        return Task.FromResult<IReadOnlyList<ConfigurationFile>>(files);
     }
 }
 

--- a/src/Confix.Tool/src/Confix.Library/ConfigurationFile/ReadConfigurationFileMiddleware.cs
+++ b/src/Confix.Tool/src/Confix.Library/ConfigurationFile/ReadConfigurationFileMiddleware.cs
@@ -36,7 +36,8 @@ public sealed class ReadConfigurationFileMiddleware : IMiddleware
                 Project = project
             };
 
-            foreach (var configurationFile in provider.GetConfigurationFiles(factoryContext))
+            foreach (var configurationFile in 
+                await provider.GetConfigurationFilesAsync(factoryContext, context.CancellationToken))
             {
                 feature.Files.Add(configurationFile);
             }

--- a/src/Confix.Tool/src/Confix.Library/Entities/Component/Inputs/GraphQL/DotnetComponentInput.cs
+++ b/src/Confix.Tool/src/Confix.Library/Entities/Component/Inputs/GraphQL/DotnetComponentInput.cs
@@ -44,7 +44,10 @@ public sealed class DotnetComponentInput : IComponentInput
 
         try
         {
-            DotnetHelpers.EnsureEmbeddedResource(csproj, _embeddedResourcePath);
+            await DotnetHelpers.EnsureEmbeddedResourceAsync(
+                csproj, 
+                _embeddedResourcePath, 
+                context.CancellationToken);
         }
         catch
         {

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Inputs/__snapshots__/DonetComponentInputTests.Should_AddEmbeddedResources_When_DotnetProjectWasButNoEmbeddedFiles.snap
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Inputs/__snapshots__/DonetComponentInputTests.Should_AddEmbeddedResources_When_DotnetProjectWasButNoEmbeddedFiles.snap
@@ -18,7 +18,6 @@
 --------------------------------------------------
 ### File: <<root>>/content/test.csproj
 --------------------------------------------------
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildProjectDirectory)/confix/components/**/*.*" />

--- a/src/Confix.Tool/test/Confix.Tool.Tests/TestHelpers/InMemoryConfigurationFileProvider.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/TestHelpers/InMemoryConfigurationFileProvider.cs
@@ -9,8 +9,10 @@ public class InMemoryConfigurationFileProvider : IConfigurationFileProvider
     public List<ConfigurationFile> Files { get; } = new();
 
     /// <inheritdoc />
-    public IReadOnlyList<ConfigurationFile> GetConfigurationFiles(IConfigurationFileContext context)
+    public Task<IReadOnlyList<ConfigurationFile>> GetConfigurationFilesAsync(
+        IConfigurationFileContext context,
+        CancellationToken ct)
     {
-        return Files;
+        return Task.FromResult<IReadOnlyList<ConfigurationFile>>(Files);
     }
 }


### PR DESCRIPTION
- Removes the xml declaration header from csproj after parsing:
![image](https://github.com/SwissLife-OSS/Confix/assets/6861396/d41999d6-4e30-48c3-a32d-562355ebb3b8)
- Fixes the formatting of added EmbeddedResources and UserSecrets
![image](https://github.com/SwissLife-OSS/Confix/assets/6861396/6e108828-454b-4299-aa20-172db25e6129)
![image](https://github.com/SwissLife-OSS/Confix/assets/6861396/59a11d4f-fe8e-4f29-9595-7a0d16455ffb)

