### PR TITLE
Allow 'unsafe' characters in outputting config json

### DIFF
--- a/src/Confix.Tool/src/Confix.Library/Utilities/Json/JsonNodeExtensions.cs
+++ b/src/Confix.Tool/src/Confix.Library/Utilities/Json/JsonNodeExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -41,10 +42,10 @@ public static partial class JsonNodeExtensions
 
             (_, JsonValue nodeValue) => nodeValue,
             _ => throw new InvalidOperationException($"""
-                    Cannot merge nodes of different types:
-                    Source: {source.GetSchemaValueType()}
-                    Node: {node.GetSchemaValueType()}
-                """)
+                                                          Cannot merge nodes of different types:
+                                                          Source: {source.GetSchemaValueType()}
+                                                          Node: {node.GetSchemaValueType()}
+                                                      """)
         };
 
     private static JsonArray Merge(this JsonArray source, JsonArray node)
@@ -200,7 +201,10 @@ public static partial class JsonNodeExtensions
         => await JsonSerializer.SerializeAsync(
             stream,
             node,
-            new JsonSerializerOptions { WriteIndented = true },
+            new JsonSerializerOptions
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, WriteIndented = true
+            },
             cancellationToken);
 
     [GeneratedRegex(@"^(?<name>.+?)\[(?<index>\d+)]$")]

--- a/src/Confix.Tool/src/Confix.Library/Utilities/Json/JsonNodeExtensions.cs
+++ b/src/Confix.Tool/src/Confix.Library/Utilities/Json/JsonNodeExtensions.cs
@@ -42,10 +42,10 @@ public static partial class JsonNodeExtensions
 
             (_, JsonValue nodeValue) => nodeValue,
             _ => throw new InvalidOperationException($"""
-                                                          Cannot merge nodes of different types:
-                                                          Source: {source.GetSchemaValueType()}
-                                                          Node: {node.GetSchemaValueType()}
-                                                      """)
+                    Cannot merge nodes of different types:
+                    Source: {source.GetSchemaValueType()}
+                    Node: {node.GetSchemaValueType()}
+                """)
         };
 
     private static JsonArray Merge(this JsonArray source, JsonArray node)
@@ -203,7 +203,8 @@ public static partial class JsonNodeExtensions
             node,
             new JsonSerializerOptions
             {
-                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, WriteIndented = true
+                WriteIndented = true,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             },
             cancellationToken);
 


### PR DESCRIPTION
Characters like ' < > are not more escaped: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/character-encoding.