### PR TITLE
Fix build when variable contains null

### DIFF
--- a/src/Confix.Tool/src/Confix.Library/Variables/JsonParser.cs
+++ b/src/Confix.Tool/src/Confix.Library/Variables/JsonParser.cs
@@ -5,12 +5,13 @@ namespace Confix.Variables;
 
 public static class JsonParser
 {
-    public static Dictionary<string, JsonNode?> ParseNode(JsonNode node)
+    public static Dictionary<string, JsonNode?> ParseNode(JsonNode? node)
         => node switch
         {
             JsonArray array => ParseArray(array).ToDictionary(),
             JsonObject obj => ParseObject(obj).ToDictionary(),
             JsonValue => throw new JsonParserException("Node must be an JsonObject or JsonArray"),
+            null => new Dictionary<string, JsonNode?>{ {"", null} },
             _ => throw new JsonParserException($"Cant parse type {node.GetType().Name}")
         };
 


### PR DESCRIPTION
Fixes the object reference exception when referenced variable contains null as value.