### PR TITLE
Return provider-transformed path from variable set

### DIFF
--- a/src/Confix.Tool/src/Confix.Library/Variables/VariableResolver.cs
+++ b/src/Confix.Tool/src/Confix.Library/Variables/VariableResolver.cs
@@ -30,9 +30,9 @@ public sealed class VariableResolver : IVariableResolver
 
         await using var provider = _variableProviderFactory.CreateProvider(configuration);
 
-        await provider.SetAsync(path.Path, value, context);
+        var resolvedPath = await provider.SetAsync(path.Path, value, context);
 
-        return path;
+        return new VariablePath(path.ProviderName, resolvedPath);
     }
 
     public async Task<IEnumerable<VariablePath>> ListVariables(IVariableProviderContext context)

--- a/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariableResolverTests.cs
+++ b/src/Confix.Tool/test/Confix.Tool.Tests/Variables/VariableResolverTests.cs
@@ -171,4 +171,87 @@ public class VariableResolverTests
         await Assert.ThrowsAsync<ExitException>(() =>
             resolver.ResolveVariables(keys, context));
     }
+
+    [Fact]
+    public async Task SetVariable_ProviderReturnsTransformedPath_ReturnsPathWithProviderName()
+    {
+        // Arrange – simulates the `secret` provider, whose SetAsync returns the
+        // Base64-encoded ciphertext rather than the input path. The resolver must
+        // propagate that transformed path so the CLI can display it to the user.
+        var factoryMock = new Mock<IVariableProviderFactory>();
+
+        var configurations = new List<VariableProviderConfiguration>
+        {
+            new VariableProviderConfiguration
+            {
+                Name = "secret",
+                Type = "secret",
+                Configuration = JsonNode.Parse("{}")!
+            }
+        };
+
+        const string inputPath = "irrelevant";
+        const string cipherTextPath = "K2b8F2zG9HpJxMImaYwlf0ByzArc+abc/def==";
+        var value = JsonValue.Create("super-secret")!;
+
+        var providerMock = new Mock<IVariableProvider>();
+        providerMock
+            .Setup(p => p.SetAsync(inputPath, value, It.IsAny<IVariableProviderContext>()))
+            .ReturnsAsync(cipherTextPath);
+
+        factoryMock.Setup(f => f.CreateProvider(configurations[0]))
+            .Returns(providerMock.Object);
+
+        var resolver = new VariableResolver(factoryMock.Object, new VariableListCache(), configurations);
+        var context = new VariableProviderContext(null!, CancellationToken.None);
+
+        // Act
+        var result = await resolver.SetVariable(
+            new VariablePath("secret", inputPath),
+            value,
+            context);
+
+        // Assert
+        result.ProviderName.Should().Be("secret");
+        result.Path.Should().Be(cipherTextPath);
+        result.ToString().Should().Be($"$secret:{cipherTextPath}");
+    }
+
+    [Fact]
+    public async Task SetVariable_ProviderReturnsSamePath_ReturnsPathUnchanged()
+    {
+        // Arrange – simulates the `local` provider, whose SetAsync returns the
+        // original path unchanged.
+        var factoryMock = new Mock<IVariableProviderFactory>();
+
+        var configurations = new List<VariableProviderConfiguration>
+        {
+            new VariableProviderConfiguration
+            {
+                Name = "Provider1",
+                Type = "local",
+                Configuration = JsonNode.Parse("""{ "path": "/path/to/file.json" }""")!
+            }
+        };
+
+        var providerMock = new Mock<IVariableProvider>();
+        providerMock
+            .Setup(p => p.SetAsync("Key1", It.IsAny<JsonNode>(), It.IsAny<IVariableProviderContext>()))
+            .ReturnsAsync("Key1");
+
+        factoryMock.Setup(f => f.CreateProvider(configurations[0]))
+            .Returns(providerMock.Object);
+
+        var resolver = new VariableResolver(factoryMock.Object, new VariableListCache(), configurations);
+        var context = new VariableProviderContext(null!, CancellationToken.None);
+
+        // Act
+        var result = await resolver.SetVariable(
+            new VariablePath("Provider1", "Key1"),
+            JsonValue.Create("v")!,
+            context);
+
+        // Assert
+        result.Should().Be(new VariablePath("Provider1", "Key1"));
+    }
 }


### PR DESCRIPTION
## Problem

When invoking `confix variable set` against the `secret` provider, the CLI
prints the original input name instead of the encrypted ciphertext, even
though the documentation promises the ciphertext:

```bash
$ confix variable set '$secret:irrelevant' 'my-secret-value'
✓ Variable $secret:irrelevant set successfully.    # ← should be $secret:<base64>