### PR TITLE
fix: prevent unicode escaping of '+' in variable get output

### DIFF
--- a/src/Confix.Tool/src/Confix.Library/Output/JsonNodeOutputFormatter.cs
+++ b/src/Confix.Tool/src/Confix.Library/Output/JsonNodeOutputFormatter.cs
@@ -1,3 +1,5 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Confix.Tool.Commands.Logging;
 using Confix.Tool.Reporting;
@@ -6,6 +8,11 @@ namespace Confix.Tool.Commands.Configuration;
 
 public sealed class JsonNodeOutputFormatter : IOutputFormatter<JsonNode>
 {
+    private static readonly JsonSerializerOptions _options = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
     /// <inheritdoc />
     public bool CanHandle(OutputFormat format, JsonNode value)
         => format == OutputFormat.Json;
@@ -13,6 +20,6 @@ public sealed class JsonNodeOutputFormatter : IOutputFormatter<JsonNode>
     /// <inheritdoc />
     public Task<string> FormatAsync(OutputFormat format, JsonNode value)
     {
-        return Task.FromResult(value.ToJsonString());
+        return Task.FromResult(value.ToJsonString(_options));
     }
 }

--- a/src/Confix.Tool/src/Confix.Library/Pipelines/Variable/VariableGetPipeline.cs
+++ b/src/Confix.Tool/src/Confix.Library/Pipelines/Variable/VariableGetPipeline.cs
@@ -38,7 +38,7 @@ public sealed class VariableGetPipeline : Pipeline
         var result = await resolver
             .ResolveOrThrowAsync(variablePath, variableContext);
 
-        context.Logger.PrintVariableResolved(variablePath, result.ToJsonString());
+        context.Logger.PrintVariableResolved(variablePath, result.ToString());
 
         context.SetOutput(result);
     }


### PR DESCRIPTION
JsonNode.ToJsonString() uses JavaScriptEncoder.Default which unnecessarily escapes '+' (U+002B) as \u002b in the output.

- VariableGetPipeline: use result.ToString() for console display to get the raw string value without JSON encoding artifacts
- JsonNodeOutputFormatter: pass JavaScriptEncoder.UnsafeRelaxedJsonEscaping to ToJsonString() so --format json output preserves '+' literally